### PR TITLE
Implement a stack with RAII slots

### DIFF
--- a/hane-kernel/src/error.rs
+++ b/hane-kernel/src/error.rs
@@ -1,4 +1,4 @@
-use crate::{Stack, Term, entry::Entry};
+use crate::{entry::Entry, Stack, Term};
 
 pub enum CommandError<M, B> {
     NameAlreadyExists(String),
@@ -6,7 +6,7 @@ pub enum CommandError<M, B> {
 }
 
 pub struct TypeError<M, B> {
-    pub bindings: Stack<B>,
+    pub bindings: Vec<B>,
     pub variant: TypeErrorVariant<M, B>,
 }
 
@@ -22,7 +22,7 @@ pub enum TypeErrorVariant<M, B> {
 impl<M, B: Clone> TypeError<M, B> {
     pub fn new(lenv: &mut Stack<Entry<M, B>>, variant: TypeErrorVariant<M, B>) -> Self {
         TypeError {
-            bindings: lenv.iter().rev().map(|entry|entry.x.clone()).collect(),
+            bindings: lenv.iter().rev().map(|entry| entry.x.clone()).collect(),
             variant,
         }
     }

--- a/hane-kernel/src/error.rs
+++ b/hane-kernel/src/error.rs
@@ -6,6 +6,7 @@ pub enum CommandError<M, B> {
 }
 
 pub struct TypeError<M, B> {
+    /// the local binding context of the terms in the error
     pub bindings: Vec<B>,
     pub variant: TypeErrorVariant<M, B>,
 }

--- a/hane-kernel/src/error.rs
+++ b/hane-kernel/src/error.rs
@@ -7,7 +7,7 @@ pub enum CommandError<M, B> {
 
 pub struct TypeError<M, B> {
     /// the local binding context of the terms in the error
-    pub bindings: Vec<B>,
+    pub bindings: Stack<B>,
     pub variant: TypeErrorVariant<M, B>,
 }
 

--- a/hane-kernel/src/global.rs
+++ b/hane-kernel/src/global.rs
@@ -50,7 +50,9 @@ impl<M: Clone, B: Clone> Global<M, B> {
 
     pub fn get(&self, name: &str) -> Option<EntryRef<M, B>> {
         self.env.iter().find_map(|(_, entry)| match entry {
-            GEntry::Definition(x, ttype, value) => (x == name).then_some(EntryRef::with_value(value, ttype)),
+            GEntry::Definition(x, ttype, value) => {
+                (x == name).then_some(EntryRef::with_value(value, ttype))
+            }
             GEntry::Axiom(x, ttype) => (x == name).then_some(EntryRef::new(ttype)),
         })
     }
@@ -63,7 +65,8 @@ impl<M: Clone, B: Clone> Global<M, B> {
         value: Term<M, B>,
     ) -> Result<(), (M, CommandError<M, B>)> {
         self.free(&name).map_err(|err| (meta.clone(), err))?;
-        let mut lenv = Stack::new();
+        let mut buf = Vec::new();
+        let mut lenv = Stack::new(&mut buf);
         let sort = ttype
             .type_check(self, &mut lenv)
             .map_err(|(meta, err)| (meta, CommandError::TypeError(err)))?;
@@ -87,7 +90,8 @@ impl<M: Clone, B: Clone> Global<M, B> {
         ttype: Term<M, B>,
     ) -> Result<(), (M, CommandError<M, B>)> {
         self.free(&name).map_err(|err| (meta.clone(), err))?;
-        let mut lenv = Stack::new();
+        let mut buf = Vec::new();
+        let mut lenv = Stack::new(&mut buf);
         let sort = ttype
             .type_check(self, &mut lenv)
             .map_err(|(meta, err)| (meta, CommandError::TypeError(err)))?;

--- a/hane-kernel/src/global.rs
+++ b/hane-kernel/src/global.rs
@@ -89,8 +89,7 @@ impl<M: Clone, B: Clone> Global<M, B> {
         ttype: Term<M, B>,
     ) -> Result<(), (M, CommandError<M, B>)> {
         self.free(&name).map_err(|err| (meta.clone(), err))?;
-        let mut stack = Stack::new();
-        let mut lenv = stack.slot();
+        let mut lenv = Stack::new();
         let sort = ttype
             .type_check(self, &mut lenv)
             .map_err(|(meta, err)| (meta, CommandError::TypeError(err)))?;

--- a/hane-kernel/src/global.rs
+++ b/hane-kernel/src/global.rs
@@ -65,8 +65,7 @@ impl<M: Clone, B: Clone> Global<M, B> {
         value: Term<M, B>,
     ) -> Result<(), (M, CommandError<M, B>)> {
         self.free(&name).map_err(|err| (meta.clone(), err))?;
-        let mut buf = Vec::new();
-        let mut lenv = Stack::new(&mut buf);
+        let mut lenv = Stack::new();
         let sort = ttype
             .type_check(self, &mut lenv)
             .map_err(|(meta, err)| (meta, CommandError::TypeError(err)))?;
@@ -90,8 +89,8 @@ impl<M: Clone, B: Clone> Global<M, B> {
         ttype: Term<M, B>,
     ) -> Result<(), (M, CommandError<M, B>)> {
         self.free(&name).map_err(|err| (meta.clone(), err))?;
-        let mut buf = Vec::new();
-        let mut lenv = Stack::new(&mut buf);
+        let mut stack = Stack::new();
+        let mut lenv = stack.slot();
         let sort = ttype
             .type_check(self, &mut lenv)
             .map_err(|(meta, err)| (meta, CommandError::TypeError(err)))?;

--- a/hane-kernel/src/stack.rs
+++ b/hane-kernel/src/stack.rs
@@ -2,7 +2,7 @@ use std::iter::Rev;
 use std::mem::ManuallyDrop;
 
 /// A stack separated into sections called slots. Each `Stack<'a, T>` represents one such slot.
-/// When a slot is droped so is all the elements of that section.
+/// When a slot is dropped, so are all the elements of that section.
 pub struct Stack<'a, T> {
     buf: ManuallyDrop<&'a mut Vec<T>>,
     /// The starting index of this stack slot
@@ -56,7 +56,7 @@ impl<'a, T> Stack<'a, T> {
     /// Removes all elements of this slot from the stack and returns an iterator over them
     pub fn pop(mut self) -> Rev<std::vec::Drain<'a, T>> {
         let slot = self.slot;
-        // Safety: `buf` is leaked immediately after `ManuallyDrop::take`. It can therefor not be
+        // Safety: `buf` is leaked immediately after `ManuallyDrop::take`. It can therefore not be
         // used again. Not even in the drop implementation
         let buf = unsafe {
             let buf = ManuallyDrop::take(&mut self.buf);

--- a/hane-kernel/src/stack.rs
+++ b/hane-kernel/src/stack.rs
@@ -45,7 +45,6 @@ impl<T> Stack<T> {
     }
 
     /// Returns true if the stack contains an element with the given value.
-    /// The iterator yields all items from newest to oldest.
     pub fn contains(&self, x: &T) -> bool
     where
         T: PartialEq,
@@ -54,11 +53,12 @@ impl<T> Stack<T> {
     }
 
     /// Returns an iterator over the stack.
+    /// The iterator yields all items from newest to oldest.
     pub fn iter(&self) -> Rev<std::slice::Iter<T>> {
         self.0.iter().rev()
     }
 
-    /// Creatests a new stack slot with ownership of all elements added trough it.
+    /// Creates a new stack slot with ownership of all elements added trough it.
     /// These elements are removed from the stack when the slot is dropped.
     pub fn slot(&mut self) -> StackSlot<T> {
         StackSlot {
@@ -86,7 +86,7 @@ impl<T> FromIterator<T> for Stack<T> {
 
 /// A section of a stack called a slot.
 /// When the slot is dropped, all elements of the section are removed and dropped from the stack.
-/// When creating a new slot through an existing slot, then the old slot becomes inaccepable untill the new slot is dropped.
+/// When creating a new slot through an existing slot, then the old slot becomes inaccessible until the new slot is dropped.
 #[must_use]
 pub struct StackSlot<'a, T> {
     stack: ManuallyDrop<&'a mut Stack<T>>,

--- a/hane-kernel/src/stack.rs
+++ b/hane-kernel/src/stack.rs
@@ -1,88 +1,133 @@
 use std::iter::Rev;
 use std::mem::ManuallyDrop;
+use std::ops::{Deref, DerefMut};
 
-/// A stack separated into sections called slots. Each `Stack<'a, T>` represents one such slot.
-/// When a slot is dropped, so are all the elements of that section.
-pub struct Stack<'a, T> {
-    buf: ManuallyDrop<&'a mut Vec<T>>,
-    /// The starting index of this stack slot
-    slot: usize,
-}
+/// First in last out stack, with indexation from newest to oldest entry.
+/// All elements must be inserted through a `StackSlot`.
+#[derive(Default, Clone)]
+pub struct Stack<T>(Vec<T>);
 
-impl<'a, T> Drop for Stack<'a, T> {
-    fn drop(&mut self) {
-        self.buf.truncate(self.slot);
+impl<T> From<Vec<T>> for Stack<T> {
+    fn from(buf: Vec<T>) -> Self {
+        Stack(buf)
     }
 }
 
-impl<'a, T> Stack<'a, T> {
-    pub fn new(buf: &'a mut Vec<T>) -> Self {
-        Stack {
-            slot: buf.len(),
-            buf: ManuallyDrop::new(buf),
-        }
+impl<T> Stack<T> {
+    pub fn new() -> Self {
+        Stack(Vec::new())
     }
 
+    /// Returns the number of elements in the stack, also referred to as its 'length'.
     pub fn len(&self) -> usize {
-        self.buf.len()
+        self.0.len()
     }
 
+    /// Returns true if the vector contains no elements.
     pub fn is_empty(&self) -> bool {
-        self.buf.is_empty()
+        self.0.is_empty()
     }
 
-    /// Creates an empty stack slot
-    #[must_use]
-    pub fn new_slot<'b>(&'b mut self) -> Stack<'b, T> {
-        Stack::new(&mut *self.buf)
-    }
-
-    /// Pushes an element onto this stack slot
-    pub fn push_on_slot(&mut self, value: T) {
-        self.buf.push(value);
-    }
-
-    /// Creates a new stack slot with a single element in it
-    #[must_use]
-    pub fn push<'b>(&'b mut self, value: T) -> Stack<'b, T> {
-        let slot = self.buf.len();
-        self.buf.push(value);
-        Stack {
-            buf: ManuallyDrop::new(&mut *self.buf),
-            slot,
-        }
-    }
-
-    /// Removes all elements of this slot from the stack and returns an iterator over them
-    pub fn pop(mut self) -> Rev<std::vec::Drain<'a, T>> {
-        let slot = self.slot;
-        // Safety: `buf` is leaked immediately after `ManuallyDrop::take`. It can therefore not be
-        // used again. Not even in the drop implementation
-        let buf = unsafe {
-            let buf = ManuallyDrop::take(&mut self.buf);
-            std::mem::forget(self);
-            buf
-        };
-        buf.drain(slot..).rev()
-    }
-
+    /// Returns a reference to the `index`th newest element or None if out of bounds.
     pub fn get(&self, index: usize) -> Option<&T> {
-        if index < self.buf.len() {
+        if index < self.0.len() {
             // Safety: `index` is checked to be within bounds
-            Some(unsafe { self.buf.get_unchecked(self.buf.len() - 1 - index) })
+            Some(unsafe { self.0.get_unchecked(self.0.len() - 1 - index) })
         } else {
             None
         }
     }
 
+    /// Shortens the stack, keeping the oldest len elements and dropping the rest.
+    /// If len is greater than the stack's current length, this has no effect.
+    pub fn truncate(&mut self, len: usize) {
+        self.0.truncate(len)
+    }
+
+    /// Returns true if the stack contains an element with the given value.
+    /// The iterator yields all items from newest to oldest.
     pub fn contains(&self, x: &T) -> bool
     where
         T: PartialEq,
     {
-        self.buf.contains(x)
+        self.0.contains(x)
     }
 
+    /// Returns an iterator over the stack.
     pub fn iter(&self) -> Rev<std::slice::Iter<T>> {
-        self.buf.iter().rev()
+        self.0.iter().rev()
+    }
+
+    /// Creatests a new stack slot with ownership of all elements added trough it.
+    /// These elements are removed from the stack when the slot is dropped.
+    #[must_use]
+    pub fn slot(&mut self) -> StackSlot<T> {
+        StackSlot { slot: self.len(), stack: ManuallyDrop::new(self) }
+    }
+
+    /// Creates a new stack slot with a single element
+    pub fn push(&mut self, value: T) -> StackSlot<T> {
+        let slot = self.0.len();
+        self.0.push(value);
+        StackSlot {
+            stack: ManuallyDrop::new(self),
+            slot,
+        }
+    }
+}
+
+impl<T> FromIterator<T> for Stack<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Stack(Vec::from_iter(iter))
+    }
+}
+
+/// A section of a stack called a slot.
+/// When the slot is dropped, all elements of the section are removed and dropped from the stack.
+/// When creating a new slot through an existing slot, then the old slot becomes inaccepable untill the new slot is dropped.
+#[must_use]
+pub struct StackSlot<'a, T> {
+    stack: ManuallyDrop<&'a mut Stack<T>>,
+    /// The starting index of this stack slot
+    slot: usize,
+}
+
+impl<'a, T> Deref for StackSlot<'a, T> {
+    type Target = Stack<T>;
+
+    fn deref(&self) -> &Stack<T> {
+        &self.stack
+    }
+}
+
+impl<'a, T> DerefMut for StackSlot<'a, T> {
+    fn deref_mut(&mut self) -> &mut Stack<T> {
+        &mut self.stack
+    }
+}
+
+impl<'a, T> Drop for StackSlot<'a, T> {
+    fn drop(&mut self) {
+        self.stack.truncate(self.slot);
+    }
+}
+
+impl<'a, T> StackSlot<'a, T> {
+    /// Pushes a new element in front of the stack.
+    pub fn push_onto(&mut self, value: T) {
+        self.0.push(value)
+    }
+
+    /// Removes all elements of this slot from the stack and returns an iterator over them
+    pub fn pop(mut self) -> Rev<std::vec::Drain<'a, T>> {
+        let slot = self.slot;
+        // Safety: `buf` is forgotten immediately after `ManuallyDrop::take`. It can therefore not be
+        // used again. Not even in the drop implementation
+        let buf = unsafe {
+            let stack = ManuallyDrop::take(&mut self.stack);
+            std::mem::forget(self);
+            &mut stack.0
+        };
+        buf.drain(slot..).rev()
     }
 }

--- a/hane-kernel/src/stack.rs
+++ b/hane-kernel/src/stack.rs
@@ -1,4 +1,3 @@
-use std::iter::Rev;
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 
@@ -54,7 +53,7 @@ impl<T> Stack<T> {
 
     /// Returns an iterator over the stack.
     /// The iterator yields all items from newest to oldest.
-    pub fn iter(&self) -> Rev<std::slice::Iter<T>> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &T> {
         self.0.iter().rev()
     }
 
@@ -121,7 +120,7 @@ impl<'a, T> StackSlot<'a, T> {
     }
 
     /// Removes all elements of this slot from the stack and returns an iterator over them
-    pub fn pop(mut self) -> Rev<std::vec::Drain<'a, T>> {
+    pub fn pop(mut self) -> impl DoubleEndedIterator<Item = T> + 'a {
         let slot = self.slot;
         // Safety: `buf` is forgotten immediately after `ManuallyDrop::take`. It can therefore not be
         // used again. Not even in the drop implementation

--- a/hane-kernel/src/stack.rs
+++ b/hane-kernel/src/stack.rs
@@ -60,9 +60,11 @@ impl<T> Stack<T> {
 
     /// Creatests a new stack slot with ownership of all elements added trough it.
     /// These elements are removed from the stack when the slot is dropped.
-    #[must_use]
     pub fn slot(&mut self) -> StackSlot<T> {
-        StackSlot { slot: self.len(), stack: ManuallyDrop::new(self) }
+        StackSlot {
+            slot: self.len(),
+            stack: ManuallyDrop::new(self),
+        }
     }
 
     /// Creates a new stack slot with a single element

--- a/hane-kernel/src/term.rs
+++ b/hane-kernel/src/term.rs
@@ -423,12 +423,10 @@ impl<M: Clone, B: Clone> Term<M, B> {
                 let x_sort = x_sort
                     .expect_sort(global, lenv)
                     .map_err(|err| (x_tp.meta.clone(), err))?;
-                let t_tp = {
-                    let mut lenv = lenv.push(Entry::new(x.clone(), x_tp.clone()));
-                    t.type_check(global, &mut lenv)?
-                };
+                let mut lenv = lenv.push(Entry::new(x.clone(), x_tp.clone()));
+                let t_tp = t.type_check(global, &mut lenv)?;
                 let t_sort = t_tp
-                    .expect_sort(global, lenv)
+                    .expect_sort(global, &mut lenv)
                     .map_err(|err| (t.meta.clone(), err))?;
                 Term {
                     meta: self.meta.clone(),

--- a/hane-kernel/src/term.rs
+++ b/hane-kernel/src/term.rs
@@ -438,10 +438,8 @@ impl<M: Clone, B: Clone> Term<M, B> {
                 x_sort
                     .expect_sort(global, lenv)
                     .map_err(|err| (x_tp.meta.clone(), err))?;
-                let t_tp = {
-                    let mut lenv = lenv.push(Entry::new(x.clone(), x_tp.clone()));
-                    t.type_check(global, &mut lenv)?
-                };
+                let mut lenv = lenv.push(Entry::new(x.clone(), x_tp.clone()));
+                let t_tp = t.type_check(global, &mut lenv)?;
                 Term {
                     meta: self.meta.clone(),
                     variant: Box::new(TermVariant::Product(x.clone(), x_tp.clone(), t_tp)),

--- a/hane-kernel/src/term.rs
+++ b/hane-kernel/src/term.rs
@@ -245,15 +245,13 @@ impl<M: Clone, B: Clone> Term<M, B> {
                 }
                 TermVariant::Product(x, input_type, output_type) => {
                     input_type.normalize(global, lenv);
-                    lenv.push(Entry::new(x.clone(), input_type.clone()));
-                    output_type.normalize(global, lenv);
-                    lenv.pop();
+                    let mut lenv = lenv.push(Entry::new(x.clone(), input_type.clone()));
+                    output_type.normalize(global, &mut lenv);
                 }
                 TermVariant::Abstract(x, input_type, body) => {
                     input_type.normalize(global, lenv);
-                    lenv.push(Entry::new(x.clone(), input_type.clone()));
-                    body.normalize(global, lenv);
-                    lenv.pop();
+                    let mut lenv = lenv.push(Entry::new(x.clone(), input_type.clone()));
+                    body.normalize(global, &mut lenv);
                 }
                 TermVariant::Bind(_name, _type, val, t) => {
                     val.normalize(global, lenv);
@@ -312,10 +310,10 @@ impl<M: Clone, B: Clone> Term<M, B> {
         if this == other {
             Ok(())
         } else {
-            Err(TypeError::new(lenv, TypeErrorVariant::IncompatibleTypes(
-                other.clone(),
-                self.clone(),
-            )))
+            Err(TypeError::new(
+                lenv,
+                TypeErrorVariant::IncompatibleTypes(other.clone(), self.clone()),
+            ))
         }
     }
 
@@ -344,10 +342,10 @@ impl<M: Clone, B: Clone> Term<M, B> {
         if this.subtype_inner(&other, global) {
             Ok(())
         } else {
-            Err(TypeError::new(lenv, TypeErrorVariant::IncompatibleTypes(
-                other.clone(),
-                self.clone(),
-            )))
+            Err(TypeError::new(
+                lenv,
+                TypeErrorVariant::IncompatibleTypes(other.clone(), self.clone()),
+            ))
         }
     }
 
@@ -361,7 +359,10 @@ impl<M: Clone, B: Clone> Term<M, B> {
         if let TermVariant::Sort(sort) = *t.variant {
             Ok(sort)
         } else {
-            Err(TypeError::new(lenv, TypeErrorVariant::NotASort(self.clone())))
+            Err(TypeError::new(
+                lenv,
+                TypeErrorVariant::NotASort(self.clone()),
+            ))
         }
     }
 
@@ -422,10 +423,10 @@ impl<M: Clone, B: Clone> Term<M, B> {
                 let x_sort = x_sort
                     .expect_sort(global, lenv)
                     .map_err(|err| (x_tp.meta.clone(), err))?;
-                lenv.push(Entry::new(x.clone(), x_tp.clone()));
-                let t_tp = t.type_check(global, lenv);
-                lenv.pop();
-                let t_tp = t_tp?;
+                let t_tp = {
+                    let mut lenv = lenv.push(Entry::new(x.clone(), x_tp.clone()));
+                    t.type_check(global, &mut lenv)?
+                };
                 let t_sort = t_tp
                     .expect_sort(global, lenv)
                     .map_err(|err| (t.meta.clone(), err))?;
@@ -439,10 +440,10 @@ impl<M: Clone, B: Clone> Term<M, B> {
                 x_sort
                     .expect_sort(global, lenv)
                     .map_err(|err| (x_tp.meta.clone(), err))?;
-                lenv.push(Entry::new(x.clone(), x_tp.clone()));
-                let t_tp = t.type_check(global, lenv);
-                lenv.pop();
-                let t_tp = t_tp?;
+                let t_tp = {
+                    let mut lenv = lenv.push(Entry::new(x.clone(), x_tp.clone()));
+                    t.type_check(global, &mut lenv)?
+                };
                 Term {
                     meta: self.meta.clone(),
                     variant: Box::new(TermVariant::Product(x.clone(), x_tp.clone(), t_tp)),
@@ -458,10 +459,8 @@ impl<M: Clone, B: Clone> Term<M, B> {
                     .expect_subtype(x_tp, global, lenv)
                     .map_err(|err| (x_val.meta.clone(), err))?;
                 let t_subst = t.subst_single(0, x_val);
-                lenv.push(Entry::new(x.clone(), x_tp.clone()));
-                let t_tp = t_subst.type_check(global, lenv);
-                lenv.pop();
-                t_tp?
+                let mut lenv = lenv.push(Entry::new(x.clone(), x_tp.clone()));
+                t_subst.type_check(global, &mut lenv)?
             }
         })
     }

--- a/hane-syntax/src/eval.rs
+++ b/hane-syntax/src/eval.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use crate::{print::write_term, LoweredCommand, LoweredCommandVariant, Span, SpanError};
-use hane_kernel::{CommandError, Global, Stack, TypeErrorVariant};
+use hane_kernel::{CommandError, Global, TypeErrorVariant};
 
 pub enum EvalError {
     CommandError(CommandError<Span, String>),
@@ -15,7 +15,6 @@ impl Display for EvalError {
             }
             EvalError::CommandError(CommandError::TypeError(err)) => {
                 let mut names = err.bindings.clone();
-                let mut names = Stack::new(&mut names);
                 match &err.variant {
                     TypeErrorVariant::NotSubtypeType(expected, actual) => {
                         writeln!(f, "Invalid Subtype")?;

--- a/hane-syntax/src/eval.rs
+++ b/hane-syntax/src/eval.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use crate::{print::write_term, LoweredCommand, LoweredCommandVariant, Span, SpanError};
-use hane_kernel::{CommandError, Global, TypeErrorVariant};
+use hane_kernel::{CommandError, Global, Stack, TypeErrorVariant};
 
 pub enum EvalError {
     CommandError(CommandError<Span, String>),
@@ -15,6 +15,7 @@ impl Display for EvalError {
             }
             EvalError::CommandError(CommandError::TypeError(err)) => {
                 let mut names = err.bindings.clone();
+                let mut names = Stack::new(&mut names);
                 match &err.variant {
                     TypeErrorVariant::NotSubtypeType(expected, actual) => {
                         writeln!(f, "Invalid Subtype")?;

--- a/hane-syntax/src/lower.rs
+++ b/hane-syntax/src/lower.rs
@@ -39,8 +39,7 @@ impl Command {
         self,
         global: &mut HashSet<String>,
     ) -> Result<LoweredCommand, SpanError<LoweringError>> {
-        let mut buf = Vec::new();
-        let mut names = Stack::new(&mut buf);
+        let mut names = Stack::new();
         let variant = match self.variant {
             CommandVariant::Definition(name, ttype, value) => {
                 if global.contains(&name) {
@@ -98,11 +97,11 @@ impl Expr {
             }
             ExprVariant::Product(binders, t) => {
                 let mut type_stack = Vec::new();
-                let mut names = names.new_slot();
+                let mut names = names.slot();
                 for Binder { name, ttype } in binders {
                     let lowered_type = ttype.lower(global, &mut names)?;
                     type_stack.push(lowered_type);
-                    names.push_on_slot(name);
+                    names.push_onto(name);
                 }
                 let t = t.lower(global, &mut names)?;
                 let mut iter = names.pop().zip(type_stack.into_iter().rev());
@@ -116,11 +115,11 @@ impl Expr {
             }
             ExprVariant::Abstract(binders, t) => {
                 let mut type_stack = Vec::new();
-                let mut names = names.new_slot();
+                let mut names = names.slot();
                 for Binder { name, ttype } in binders {
                     let lowered_type = ttype.lower(global, &mut names)?;
                     type_stack.push(lowered_type);
-                    names.push_on_slot(name);
+                    names.push_onto(name);
                 }
                 let t = t.lower(global, &mut names)?;
                 let mut iter = names.pop().zip(type_stack.into_iter().rev());

--- a/hane-syntax/src/print.rs
+++ b/hane-syntax/src/print.rs
@@ -55,10 +55,10 @@ pub fn write_term<M>(
             write!(buf, "forall {x} : ")?;
             write_term(buf, x_tp, names, 200)?;
             write!(buf, ", ")?;
-            names.push(x);
-            let r = write_term(buf, t, names, 200);
-            names.pop();
-            r?;
+            {
+                let mut names = names.push(x);
+                write_term(buf, t, &mut names, 200)?
+            }
             if level < 200 {
                 write!(buf, ")")?;
             }
@@ -72,10 +72,10 @@ pub fn write_term<M>(
             write!(buf, "fun {x} : ")?;
             write_term(buf, x_tp, names, 200)?;
             write!(buf, " => ")?;
-            names.push(x);
-            let r = write_term(buf, t, names, 200);
-            names.pop();
-            r?;
+            {
+                let mut names = names.push(x);
+                write_term(buf, t, &mut names, 200)?
+            }
             if level < 200 {
                 write!(buf, ")")?;
             }
@@ -91,10 +91,10 @@ pub fn write_term<M>(
             write!(buf, " := ")?;
             write_term(buf, x_val, names, 200)?;
             write!(buf, " in ")?;
-            names.push(x);
-            let r = write_term(buf, t, names, 200);
-            names.pop();
-            r?;
+            {
+                let mut names = names.push(x);
+                write_term(buf, t, &mut names, 200)?
+            }
             if level < 200 {
                 write!(buf, ")")?;
             }

--- a/hane-syntax/src/print.rs
+++ b/hane-syntax/src/print.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Write};
 
-use hane_kernel::{stack::Stack, term::TermVariant};
+use hane_kernel::{term::TermVariant, Stack};
 
 type Term<M> = hane_kernel::term::Term<M, String>;
 


### PR DESCRIPTION
This allows functions to simply use the `?` operator rather than needing to worry about leaving the stack in the same state as they received it. In all of our current use-cases this results in simpler more readable code.

This PR does however increase the complexity of the stack implementation (including new unsafe code).