### PR TITLE
Feature/improved spans

### DIFF
--- a/hane-syntax/src/eval.rs
+++ b/hane-syntax/src/eval.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Display, Formatter};
 
 use crate::{
     print::{write_local, write_term},
-    Span, Ident,
+    Ident, Span,
 };
 use hane_kernel::{entry::Entry, CommandError, Stack, TypeError, TypeErrorVariant};
 

--- a/hane-syntax/src/eval.rs
+++ b/hane-syntax/src/eval.rs
@@ -2,15 +2,15 @@ use std::fmt::{self, Display, Formatter};
 
 use crate::{
     print::{write_local, write_term},
-    Span,
+    Span, Ident,
 };
 use hane_kernel::{entry::Entry, CommandError, Stack, TypeError, TypeErrorVariant};
 
-pub struct EvalError(pub CommandError<Span, String>);
+pub struct EvalError(pub CommandError<Span, Ident>);
 
 fn write_cause(
-    err: &TypeError<Span, String>,
-    local: &Stack<Entry<Span, String>>,
+    err: &TypeError<Span, Ident>,
+    local: &Stack<Entry<Span, Ident>>,
     f: &mut Formatter,
 ) -> fmt::Result {
     match &err.variant {

--- a/hane-syntax/src/lib.rs
+++ b/hane-syntax/src/lib.rs
@@ -38,20 +38,33 @@ impl Span {
     }
 }
 
+#[derive(Clone)]
+pub struct Ident {
+    pub span: Span,
+    pub name: String,
+}
+
+impl Eq for Ident {}
+impl PartialEq for Ident {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
 pub struct Command {
     pub span: Span,
     pub variant: CommandVariant,
 }
 
 pub enum CommandVariant {
-    Definition(String, Expr, Expr),
-    Axiom(String, Expr),
+    Definition(Ident, Expr, Expr),
+    Axiom(Ident, Expr),
     Inductive(Vec<IndBody>),
 }
 
 /// A single type in a mutually defined inductive type set
 pub struct IndBody {
-    pub name: String,
+    pub name: Ident,
     pub params: Vec<Binder>,
     pub ttype: Expr,
     pub constructors: Vec<IndConstructor>,
@@ -59,7 +72,7 @@ pub struct IndBody {
 
 /// A single constructor of an inductive type
 pub struct IndConstructor {
-    pub name: String,
+    pub name: Ident,
     pub ttype: Expr,
 }
 
@@ -84,7 +97,7 @@ impl PartialEq for Expr {
 
 #[derive(PartialEq, Eq)]
 pub struct Binder {
-    pub name: String,
+    pub ident: Ident,
     pub ttype: Expr,
 }
 
@@ -95,7 +108,7 @@ pub enum ExprVariant {
     App(Expr, Expr),
     Product(Vec<Binder>, Expr),
     Abstract(Vec<Binder>, Expr),
-    Bind(String, Expr, Expr, Expr),
+    Bind(Ident, Expr, Expr, Expr),
 }
 
 pub struct SpanError<E> {

--- a/tests/name_collisions/double_axiom.lower.err
+++ b/tests/name_collisions/double_axiom.lower.err
@@ -1,0 +1,6 @@
+ --> tests/name_collisions/double_axiom.v:2:7
+  |
+2 | Axiom A : Prop.
+  |       ^
+  |
+  = A constant named `A` already exists

--- a/tests/name_collisions/double_axiom.v
+++ b/tests/name_collisions/double_axiom.v
@@ -1,0 +1,2 @@
+Axiom A : Prop.
+Axiom A : Prop.

--- a/tests/name_collisions/double_constructor.lower.err
+++ b/tests/name_collisions/double_constructor.lower.err
@@ -1,0 +1,6 @@
+ --> tests/name_collisions/double_constructor.v:3:7
+  |
+3 |     | a : A.
+  |       ^
+  |
+  = A constant named `a` already exists

--- a/tests/name_collisions/double_constructor.v
+++ b/tests/name_collisions/double_constructor.v
@@ -1,0 +1,3 @@
+Inductive A : Set :=
+    | a : A
+    | a : A.

--- a/tests/name_collisions/double_def.lower.err
+++ b/tests/name_collisions/double_def.lower.err
@@ -1,0 +1,6 @@
+ --> tests/name_collisions/double_def.v:2:12
+  |
+2 | Definition A : Type{0} := Set.
+  |            ^
+  |
+  = A constant named `A` already exists

--- a/tests/name_collisions/double_def.v
+++ b/tests/name_collisions/double_def.v
@@ -1,0 +1,2 @@
+Definition A : Type{0} := Prop.
+Definition A : Type{0} := Set.

--- a/tests/name_collisions/double_ind.lower.err
+++ b/tests/name_collisions/double_ind.lower.err
@@ -1,0 +1,6 @@
+ --> tests/name_collisions/double_ind.v:2:11
+  |
+2 | Inductive A : Prop :=.
+  |           ^
+  |
+  = A constant named `A` already exists

--- a/tests/name_collisions/double_ind.v
+++ b/tests/name_collisions/double_ind.v
@@ -1,0 +1,2 @@
+Inductive A : Prop :=.
+Inductive A : Prop :=.


### PR DESCRIPTION
This improves error messages by adding spans to identifiers. Thereby allowing errors to refer to the identifier rather than the entire command.