### PR TITLE
Feature/def bindings

### DIFF
--- a/hane-syntax/src/grammar.pest
+++ b/hane-syntax/src/grammar.pest
@@ -6,7 +6,7 @@ command_definition = {
 command_axiom = { keyword_axiom ~ ident ~ ":" ~ expr ~ "." }
 command_inductive = { keyword_inductive ~ inductive_body ~ (keyword_with ~ inductive_body)* ~ "." }
 
-inductive_body = { ident ~ binders_opt ~ ":" ~ expr ~ ":=" ~ inductive_constructors }
+inductive_body = { ident ~ binders ~ ":" ~ expr ~ ":=" ~ inductive_constructors }
 inductive_constructors = { inductive_constructor? ~ ("|" ~ inductive_constructor)* }
 inductive_constructor = { ident ~ ":" ~ expr }
 
@@ -17,8 +17,8 @@ expr_inner = _{
 }
 expr_paren = { "(" ~ expr ~ ")" }
 expr_var = { ident }
-expr_product = { keyword_forall ~ binders ~ "," ~ expr }
-expr_abstract = { keyword_fun ~ binders ~ "=>" ~ expr }
+expr_product = { keyword_forall ~ open_binders ~ "," ~ expr }
+expr_abstract = { keyword_fun ~ open_binders ~ "=>" ~ expr }
 expr_let_bind = {
     keyword_let ~ ident ~ ":" ~ expr ~ ":=" ~ expr ~ keyword_in ~ expr
 }
@@ -30,10 +30,10 @@ expr_match_arms = { expr_match_arm? ~ ("|" ~ expr_match_arm)* }
 expr_match_arm = { pattern ~ "=>" ~ expr }
 pattern = { ident ~ ident* }
 
-binders_opt = { binder_base | binder_paren* }
-binders = { binder_base | binder_paren+ }
-binder_paren = _{ "(" ~ binder_base ~ ")" }
-binder_base = { ident ~ ":" ~ expr}
+binders = { binder* }
+open_binders = { open_binder | binder+ }
+binder = _{ "(" ~ open_binder ~ ")" }
+open_binder = { ident ~ ":" ~ expr}
 
 
 sort = { sort_prop | sort_set | sort_type }

--- a/hane-syntax/src/grammar.pest
+++ b/hane-syntax/src/grammar.pest
@@ -1,7 +1,7 @@
 commands = _{ SOI ~ command* ~ EOI }
 command = _{ command_definition | command_axiom | command_inductive }
 command_definition = {
-    keyword_definition ~ ident ~ ":" ~ expr ~ ":=" ~ expr ~ "."
+    keyword_definition ~ ident ~ binders ~ ":" ~ expr ~ ":=" ~ expr ~ "."
 }
 command_axiom = { keyword_axiom ~ ident ~ ":" ~ expr ~ "." }
 command_inductive = { keyword_inductive ~ inductive_body ~ (keyword_with ~ inductive_body)* ~ "." }

--- a/hane-syntax/src/lib.rs
+++ b/hane-syntax/src/lib.rs
@@ -57,7 +57,7 @@ pub struct Command {
 }
 
 pub enum CommandVariant {
-    Definition(Ident, Expr, Expr),
+    Definition(Ident, Vec<Binder>, Expr, Expr),
     Axiom(Ident, Expr),
     Inductive(Vec<IndBody>),
 }

--- a/hane-syntax/src/parser.rs
+++ b/hane-syntax/src/parser.rs
@@ -215,12 +215,12 @@ fn parse_sort(pair: Pair) -> Sort {
 fn parse_binders(pair: Pair) -> Vec<Binder> {
     let rule = pair.as_rule();
     debug_assert!(
-        rule == Rule::binders_opt || rule == Rule::binders,
+        rule == Rule::binders || rule == Rule::open_binders,
         "{rule:?}"
     );
     pair.into_inner()
         .map(|p| {
-            debug_assert_eq!(p.as_rule(), Rule::binder_base);
+            debug_assert_eq!(p.as_rule(), Rule::open_binder);
             let mut pairs = p.into_inner();
             Binder {
                 ident: parse_ident(pairs.next().unwrap()),

--- a/hane-syntax/src/parser.rs
+++ b/hane-syntax/src/parser.rs
@@ -71,9 +71,10 @@ pub fn parse_command(pair: Pair) -> Command {
         Rule::command_definition => {
             debug_assert_rule!(pairs, keyword_definition);
             let name = parse_ident(pairs.next().unwrap());
+            let params = parse_binders(pairs.next().unwrap());
             let ttype = parse_expr(pairs.next().unwrap());
             let value = parse_expr(pairs.next().unwrap());
-            CommandVariant::Definition(name, ttype, value)
+            CommandVariant::Definition(name, params, ttype, value)
         }
         Rule::command_axiom => {
             debug_assert_rule!(pairs, keyword_axiom);

--- a/tests/inductive/logic.v
+++ b/tests/inductive/logic.v
@@ -13,49 +13,41 @@ Inductive ex (T : Set) (P : forall x : T, Prop) : Prop :=
 Inductive eq (T : Set) (x : T) : forall y : T, Prop :=
     eq_refl : eq T x x.
 
-Definition ex_falso : forall (P : Prop) (f : False), P :=
-    fun (P : Prop) (f : False) =>
-        match f as f in False return P with end.
+Definition ex_falso (P : Prop) (f : False) : P :=
+    match f as f in False return P with end.
 
-Definition and_elem : forall (P : Prop) (Q : Prop) (R : Prop) (H : forall (p : P) (q : Q), R) (p : and P Q), R :=
-    fun (P : Prop) (Q : Prop) (R : Prop) (H : forall (p : P) (q : Q), R) (p : and P Q) =>
-        match p as p in and _ _ return R with
-        | conj _ _ p q => H p q
-        end.
+Definition and_elem (P : Prop) (Q : Prop) (R : Prop) (H : forall (p : P) (q : Q), R) (p : and P Q) : R :=
+    match p as p in and _ _ return R with
+    | conj _ _ p q => H p q
+    end.
 
-Definition or_elem : forall (P : Prop) (Q : Prop) (R : Prop) (HP : forall p : P, R) (HQ : forall q : Q, R) (o : or P Q), R :=
-    fun (P : Prop) (Q : Prop) (R : Prop) (HP : forall p : P, R) (HQ : forall q : Q, R) (o : or P Q) =>
-        match o as o in or _ _ return R with
-        | or_introl _ _ p => HP p
-        | or_intror _ _ q => HQ q
-        end.
+Definition or_elem (P : Prop) (Q : Prop) (R : Prop) (HP : forall p : P, R) (HQ : forall q : Q, R) (o : or P Q) : R :=
+    match o as o in or _ _ return R with
+    | or_introl _ _ p => HP p
+    | or_intror _ _ q => HQ q
+    end.
 
-Definition ex_elem : forall (T : Set) (P : forall x : T, Prop) (R : Prop) (H : forall (x : T) (p : P x), R) (e : ex T P), R :=
-    fun (T : Set) (P : forall x : T, Prop) (R : Prop) (H : forall (x : T) (p : P x), R) (e : ex T P) =>
-        match e as e in ex _ _ return R with
-        | ex_intro _ _ x p => H x p
-        end.
+Definition ex_elem (T : Set) (P : forall x : T, Prop) (R : Prop) (H : forall (x : T) (p : P x), R) (e : ex T P) : R :=
+    match e as e in ex _ _ return R with
+    | ex_intro _ _ x p => H x p
+    end.
 
-Definition eq_elem : forall (T : Set) (x : T) (R : forall x : T, Prop) (r : R x) (y : T) (e : eq T x y), R y :=
-    fun (T : Set) (x : T) (R : forall x : T, Prop) (r : R x) (y : T) (e : eq T x y) =>
-        match e as e in eq _ _ z return R z with
-        | eq_refl _ _ => r
-        end.
+Definition eq_elem (T : Set) (x : T) (R : forall x : T, Prop) (r : R x) (y : T) (e : eq T x y) : R y :=
+    match e as e in eq _ _ z return R z with
+    | eq_refl _ _ => r
+    end.
 
-Definition eq_sym : forall (T : Set) (x : T) (y : T) (e : eq T x y), eq T y x :=
-    fun (T : Set) (x : T) (y : T) (e : eq T x y) =>
-        match e as e in eq _ _ z return eq T z x with
-        | eq_refl _ _ => eq_refl T x
-        end.
+Definition eq_sym (T : Set) (x : T) (y : T) (e : eq T x y) : eq T y x :=
+    match e as e in eq _ _ z return eq T z x with
+    | eq_refl _ _ => eq_refl T x
+    end.
 
-Definition eq_trans : forall (T : Set) (x : T) (y : T) (z : T) (e1 : eq T x y) (e2 : eq T y z), eq T x z :=
-    fun (T : Set) (x : T) (y : T) (z : T) (e1 : eq T x y) (e2 : eq T y z) =>
-        match e2 as e2 in eq _ _ z return eq T x z with
-        | eq_refl _ _ => e1
-        end.
+Definition eq_trans (T : Set) (x : T) (y : T) (z : T) (e1 : eq T x y) (e2 : eq T y z) : eq T x z :=
+    match e2 as e2 in eq _ _ z return eq T x z with
+    | eq_refl _ _ => e1
+    end.
 
-Definition f_equal : forall (S : Set) (T : Set) (f : forall x : S, T) (x : S) (y : S) (e : eq S x y), eq T (f x) (f y) :=
-    fun (S : Set) (T : Set) (f : forall x : S, T) (x : S) (y : S) (e : eq S x y) =>
-        match e as e in eq _ _ z return eq T (f x) (f z) with
-        | eq_refl _ _ => eq_refl T (f x)
-        end.
+Definition f_equal (S : Set) (T : Set) (f : forall x : S, T) (x : S) (y : S) (e : eq S x y) : eq T (f x) (f y) :=
+    match e as e in eq _ _ z return eq T (f x) (f z) with
+    | eq_refl _ _ => eq_refl T (f x)
+    end.

--- a/tests/inductive/types.v
+++ b/tests/inductive/types.v
@@ -1,17 +1,15 @@
 Inductive prod (A : Set) (B : Set) : Set :=
     pair : forall (x : A) (y : B), prod A B.
 
-Definition fst : forall (A : Set) (B : Set) (p : prod A B), A :=
-    fun (A : Set) (B : Set) (p : prod A B) =>
-        match p as p in prod _ _ return A with
-        | pair _ _ x y => x
-        end.
+Definition fst (A : Set) (B : Set) (p : prod A B) : A :=
+    match p as p in prod _ _ return A with
+    | pair _ _ x y => x
+    end.
 
-Definition snd : forall (A : Set) (B : Set) (p : prod A B), B :=
-    fun (A : Set) (B : Set) (p : prod A B) =>
-        match p as p in prod _ _ return B with
-        | pair _ _ x y => y
-        end.
+Definition snd (A : Set) (B : Set) (p : prod A B) : B :=
+    match p as p in prod _ _ return B with
+    | pair _ _ x y => y
+    end.
 
 Inductive sum (A : Set) (B : Set) : Set :=
     | inl : forall x : A, sum A B
@@ -20,14 +18,12 @@ Inductive sum (A : Set) (B : Set) : Set :=
 Inductive sig (A : Set) (P : forall x : A, Prop) : Set :=
     exist : forall (x : A) (p : P x), sig A P.
 
-Definition proj1_sig : forall (A : Set) (P : forall x : A, Prop) (x : sig A P), A :=
-    fun (A : Set) (P : forall x : A, Prop) (x : sig A P) =>
-        match x as _ in sig _ _ return A with
-        | exist _ _ x _ => x
-        end.
+Definition proj1_sig (A : Set) (P : forall x : A, Prop) (x : sig A P) : A :=
+    match x as _ in sig _ _ return A with
+    | exist _ _ x _ => x
+    end.
 
-Definition proj2_sig : forall (A : Set) (P : forall x : A, Prop) (x : sig A P), P (proj1_sig A P x) :=
-    fun (A : Set) (P : forall x : A, Prop) (x : sig A P) =>
-        match x as x in sig _ _ return P (proj1_sig A P x) with
-        | exist _ _ _ p => p
-        end.
+Definition proj2_sig (A : Set) (P : forall x : A, Prop) (x : sig A P) : P (proj1_sig A P x) :=
+    match x as x in sig _ _ return P (proj1_sig A P x) with
+    | exist _ _ _ p => p
+    end.


### PR DESCRIPTION
This PR brings us more in line with normal coq syntax by allowing definitions to take parameters.
This only changes hane-syntax. So it's only syntactic sugar.

The main benefit of this change is that it makes our tests more readable (as seen in the changed tests).